### PR TITLE
Fix color fomatting for format-like strings

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,7 +92,11 @@ func (c *Client) Do(t TestingTB, req *Request, expectedStatusCode int) *Response
 		t.Fatalf("can't dump request: %s", err)
 	}
 
-	colorF := func(b []byte) string { return color.BlueString(string(b)) }
+	// color methods *String accepts format as first argument
+	// any format-like strings passed to it will be treated as format string
+	// ex. URL encoded strings /content?from=2016-03-31T08%3A00%3A00%2B03%3A00
+	// we should explicitly pass `%s` format as first argument
+	colorF := func(b []byte) string { return color.BlueString("%s", string(b)) }
 	if *vF {
 		t.Logf("\n%s\n%s\n\n%s\n", colorF(status), colorF(headers), colorF(body))
 	} else {
@@ -128,11 +132,11 @@ func (c *Client) Do(t TestingTB, req *Request, expectedStatusCode int) *Response
 
 	switch {
 	case resp.StatusCode >= 400:
-		colorF = func(b []byte) string { return color.RedString(string(b)) }
+		colorF = func(b []byte) string { return color.RedString("%s", string(b)) }
 	case resp.StatusCode >= 300:
-		colorF = func(b []byte) string { return color.YellowString(string(b)) }
+		colorF = func(b []byte) string { return color.YellowString("%s", string(b)) }
 	default:
-		colorF = func(b []byte) string { return color.GreenString(string(b)) }
+		colorF = func(b []byte) string { return color.GreenString("%s", string(b)) }
 	}
 
 	if *vF {

--- a/client_test.go
+++ b/client_test.go
@@ -1,8 +1,12 @@
 package gophers
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -16,4 +20,47 @@ func TestUpdateRequest(t *testing.T) {
 	req := client.NewRequest(t, "POST", "/user", nil)
 	require.Equal(t, "https://host.example/prefix/user?foo=bar", req.URL.String())
 	require.Empty(t, req.RequestURI)
+}
+
+func TestColorLoggerFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	now := time.Now().Format(time.RFC3339)
+	v := url.Values{}
+	v.Add("time", now)
+
+	u, err := url.Parse(server.URL)
+	require.Nil(t, err)
+	u.RawQuery = v.Encode()
+
+	ft := new(FakeT)
+	client := NewClient(*u)
+	req := client.NewRequest(t, "GET", "/user", nil)
+	client.Do(ft, req, 200)
+
+	require.Equal(t, []string{
+		"\n[\x1b[34mGET /user?time=" + url.QueryEscape(now) + " HTTP/1.1\x1b[0m]\n",
+		"\n[\x1b[32mHTTP/1.1 200 OK\x1b[0m]\n",
+	}, ft.Logs)
+
+	require.Empty(t, ft.Errors)
+	require.Empty(t, ft.Fatals)
+}
+
+type FakeT struct {
+	Logs   []string
+	Errors []string
+	Fatals []string
+}
+
+func (f *FakeT) Logf(format string, a ...interface{}) {
+	f.Logs = append(f.Logs, fmt.Sprintf(format, a))
+}
+
+func (f *FakeT) Errorf(format string, a ...interface{}) {
+	f.Errors = append(f.Errors, fmt.Sprintf(format, a))
+}
+
+func (f *FakeT) Fatalf(format string, a ...interface{}) {
+	f.Fatals = append(f.Fatals, fmt.Sprintf(format, a))
 }


### PR DESCRIPTION
Color methods `*String` accepts format as first argument. So any format-like strings passed to it will be treated as format string. We should explicitly pass `%s` format as first argument or it will lead to wrong formatting.
